### PR TITLE
Bugfix with spamming SSL warning

### DIFF
--- a/src/main/java/levelpoints/levelpoints/SQL.java
+++ b/src/main/java/levelpoints/levelpoints/SQL.java
@@ -169,7 +169,7 @@ public class SQL {
         String table = (String) getCacheData("table");
 
         try {
-            setConnection(DriverManager.getConnection("jdbc:mysql://" + host + ":" +port + "/" + database, username, password));
+            setConnection(DriverManager.getConnection("jdbc:mysql://" + host + ":" +port + "/" + database + "?autoReconnect=true&useSSL=false", username, password));
         } catch (SQLException e) {
             e.printStackTrace();
         }
@@ -213,7 +213,7 @@ public class SQL {
                 }
                 Class.forName("com.mysql.jdbc.Driver");
                 LevelPoints.getInstance().getLogger().info("About to connect to database");
-                setConnection(DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database, username, password));
+                setConnection(DriverManager.getConnection("jdbc:mysql://" + host + ":" + port + "/" + database + "?autoReconnect=true&useSSL=false", username, password));
                 statment = connection.createStatement();
                 statment.executeUpdate("CREATE TABLE IF NOT EXISTS `"+ table +"` (`UUID` varchar(200), `NAME` varchar(200), `LEVEL` INT(10), EXP DOUBLE(10,2), PRESTIGE INT(10), ACTIVEBOOSTER DOUBLE(10,2), BOOSTEROFF varchar(200), BOOSTERS TEXT(60000))");
                 System.out.println(ChatColor.DARK_GREEN + "MySQL Connected");


### PR DESCRIPTION
Removed spamming this message:
[22:57:08] [Craft Scheduler Thread - 0/WARN]: Fri Feb 05 22:57:08 CET 2021 WARN: Establishing SSL connection without server's identity verification is not recommended. According to MySQL 5.5.45+, 5.6.26+ and 5.7.6+ requirements SSL connection must be established by default if explicit option isn't set. For compliance with existing applications not using SSL the verifyServerCertificate property is set to 'false'. You need either to explicitly disable SSL by setting useSSL=false, or set useSSL=true and provide truststore for server certificate verification.