### PR TITLE
Progress bar feature and bugfixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         </repository>
         <repository>
             <id>placeholderapi</id>
-            <url>http://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
         </repository>
         <repository>
             <id>sk89q-repo</id>

--- a/src/main/java/me/zoon20x/levelpoints/LevelPoints.java
+++ b/src/main/java/me/zoon20x/levelpoints/LevelPoints.java
@@ -25,6 +25,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.File;
 import java.math.BigDecimal;
@@ -295,7 +296,7 @@ public final class LevelPoints extends JavaPlugin{
     public static boolean isRunningSQL() {
         return isRunningSQL;
     }
-    public static LevelColorSettings getLevelColorSettings() {
+    public static @Nullable LevelColorSettings getLevelColorSettings() {
         return levelColorSettings;
     }
 

--- a/src/main/java/me/zoon20x/levelpoints/LevelPoints.java
+++ b/src/main/java/me/zoon20x/levelpoints/LevelPoints.java
@@ -116,8 +116,6 @@ public final class LevelPoints extends JavaPlugin{
             getDebug(DebugSeverity.NORMAL, "Loaded Placeholder expansion");
         }
 
-
-
         if(getConfig().getBoolean("MySQL.Enabled")) {
             sql = new MySQL(
                     getConfig().getString(DataLocation.sqlHost),
@@ -130,6 +128,21 @@ public final class LevelPoints extends JavaPlugin{
             if(sql.isConnected()) {
                 isRunningSQL = true;
             }
+        }
+
+        if(getConfig().isSet("Progressbar")) {
+            ProgressStatics.userConfiguredStyle.stepMin =
+                    getConfig().getInt("Progressbar.MinStep");
+            ProgressStatics.userConfiguredStyle.stepMax =
+                    getConfig().getInt("Progressbar.MaxStep");
+
+            ProgressStatics.userConfiguredStyle.visualBorder =
+                    getConfig().getString("Progressbar.VisualBorder");
+            ProgressStatics.userConfiguredStyle.visualCompletedStep =
+                    getConfig().getString("Progressbar.VisualCompletedStep");
+            ProgressStatics.userConfiguredStyle.visualUncompletedStep =
+                    getConfig().getString("Progressbar.VisualUncompletedStep");
+
         }
 
         if(getAntiAbuseSettings().isRegionLocked()){

--- a/src/main/java/me/zoon20x/levelpoints/containers/Settings/Configs/LevelsSettings.java
+++ b/src/main/java/me/zoon20x/levelpoints/containers/Settings/Configs/LevelsSettings.java
@@ -129,7 +129,7 @@ public class LevelsSettings {
             return true;
         }
         BlockData a = BlockUtils.getBlockData(material, x);
-        if (data.getLevel() >= a.getPlaceRequired()) {
+        if (a != null && data.getLevel() >= a.getPlaceRequired()) {
             return true;
         }
         return false;

--- a/src/main/java/me/zoon20x/levelpoints/events/CustomEvents/EventUtils.java
+++ b/src/main/java/me/zoon20x/levelpoints/events/CustomEvents/EventUtils.java
@@ -73,7 +73,12 @@ public class EventUtils {
         Bukkit.getPluginManager().callEvent(event);
         LevelPoints.getTopListSettings().modifyLevel(data);
         LevelPoints.getTopListSettings().generateTopCache(50);
-        data.setLevelColor(LevelPoints.getLevelColorSettings().getLevelColor(level));
+
+        if(LevelPoints.getLevelColorSettings() != null)
+            data.setLevelColor(
+                    LevelPoints.getLevelColorSettings().getLevelColor(level)
+            );
+
         if(!LevelPoints.isRunningSQL()) {
             return;
         }

--- a/src/main/java/me/zoon20x/levelpoints/files/PlayerGenerator.java
+++ b/src/main/java/me/zoon20x/levelpoints/files/PlayerGenerator.java
@@ -72,11 +72,12 @@ public class PlayerGenerator {
 
 
         PlayerData data = new PlayerData(uuid, name, level, exp, requiredExp, prestige, 0, new ActiveBooster(id, date, multiplier), levelColor);
-        config.getConfigurationSection(DataLocation.BoosterList).getKeys(false).forEach(x->{
-            if(LevelPoints.getBoosterSettings().hasBooster(x)){
-                data.addBooster(LevelPoints.getBoosterSettings().getBooster(x), config.getInt(DataLocation.getUserBoosterList(x)));
-            }
-        });
+        if(config.contains(DataLocation.BoosterList))
+            config.getConfigurationSection(DataLocation.BoosterList).getKeys(false).forEach(x->{
+                if(LevelPoints.getBoosterSettings().hasBooster(x)){
+                    data.addBooster(LevelPoints.getBoosterSettings().getBooster(x), config.getInt(DataLocation.getUserBoosterList(x)));
+                }
+            });
 
 
         LevelPoints.getPlayerStorage().addData(uuid, data);

--- a/src/main/java/me/zoon20x/levelpoints/utils/LpsExpansion.java
+++ b/src/main/java/me/zoon20x/levelpoints/utils/LpsExpansion.java
@@ -50,11 +50,11 @@ public class LpsExpansion extends PlaceholderExpansion {
             return "Reloading";
         }
 
-
         UUID uuid = player.getUniqueId();
         if(!LevelPoints.getPlayerStorage().hasPlayerFile(uuid)){
             return "";
         }
+
         PlayerData data = LevelPoints.getPlayerStorage().getLoadedData(uuid);
         if(identifier.equals("player_level")){
             return MessageUtils.getLevelColor(uuid);
@@ -73,6 +73,11 @@ public class LpsExpansion extends PlaceholderExpansion {
         }
         if(identifier.equals("player_progress")){
             return data.getProgress() + "%";
+        }
+        if(identifier.equals("player_progress_bar")){
+            return ProgressStatics.makeProgressBar(null,
+                    data.getExp(), data.getRequiredExp()
+            );
         }
 
         if(identifier.equals("player_booster_id")){

--- a/src/main/java/me/zoon20x/levelpoints/utils/ProgressStatics.java
+++ b/src/main/java/me/zoon20x/levelpoints/utils/ProgressStatics.java
@@ -1,0 +1,53 @@
+package me.zoon20x.levelpoints.utils;
+
+import me.zoon20x.levelpoints.LevelPoints;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.EnumSet;
+
+/**
+ * Contains static methods providing progress bar functionality
+ */
+public class ProgressStatics {
+
+    public static BarSettings userConfiguredStyle
+            = new BarSettings();
+
+    /**
+     * Generates progress bar
+     *
+     * @param current Current progress
+     * @param target  Targeted progress
+     * @return Coloured progress bar
+     */
+    public static @NotNull String makeProgressBar(@Nullable BarSettings settings,
+                                                  double current, double target) {
+        settings = userConfiguredStyle;
+        int currentStep = 0;
+
+        if(current != 0 || target != 0)
+            currentStep = (int) Math.round(settings.stepMax * (current / target));
+
+        StringBuilder bar = new StringBuilder(settings.visualBorder);
+        for(int step = settings.stepMin; step < settings.stepMax; step++) {
+            if(step <= currentStep) {
+                bar.append(settings.visualCompletedStep);
+            } else
+                bar.append(settings.visualUncompletedStep);
+        }
+        bar.append(settings.visualBorder);
+
+        return bar.toString();
+    }
+
+
+    public static class BarSettings {
+        public int stepMin = 1;
+        public int stepMax = 5;
+
+        public String visualBorder             = "§8┃";
+        public String visualCompletedStep      = "§a░";
+        public String visualUncompletedStep    = "§7░";
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -15,6 +15,13 @@ Actionbar:
     Enabled: true
     Message: '&3Level: &b{level} &3|&b {exp}/{required_exp}'
 
+Progressbar:
+  MinStep: 1
+  MaxStep: 5
+  VisualBorder: "§8┃"
+  VisualCompletedStep: "§a░"
+  VisualUncompletedStep: "§7░"
+
 TimedEXP:
   Global:
     Enabled: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: LevelPoints
 version: 3.0.0
 main: me.zoon20x.levelpoints.LevelPoints
-api-version: 1.16
+api-version: 1.17
 authors: [ Zoon20X ]
 description: Leveling plugin with custom features
 softdepend:


### PR DESCRIPTION
Bugfixes:
 - Fixed issue #9
 - Fixed issue where reading from user data is throwing NPE when BoosterList section is not found
 - Maven repository URLs must be HTTPS, otherwise maven will block that repository
 - Update API-Version to 1.17, otherwise legacy material support will be initialized by bukkit
 - Fixed issue where LevelPoints#getLevelColorSettings may be null. Causing NPE. 
 
 Features:
 - Configurable progress bars
 
![image](https://user-images.githubusercontent.com/32541639/136830979-48aaaf22-9a8a-4338-9cdf-8affe11bd6c5.png)
![image](https://user-images.githubusercontent.com/32541639/136831239-d95d3e25-6c1b-4ffc-80a6-320473f6802b.png)
![image](https://user-images.githubusercontent.com/32541639/136831594-db08d40c-fad8-4fbe-8e4b-c505712cc71a.png)

